### PR TITLE
[FEATURE] toString

### DIFF
--- a/length.js
+++ b/length.js
@@ -136,6 +136,7 @@
   proto.getValue = getValue;
   proto.getUnit = getUnit;
   proto.getString = getString;
+  proto.toString = getString;
   proto.toPrecision = toPrecision;
 
   // Expose Length prototype if user wants to add new functions.

--- a/src/length.js
+++ b/src/length.js
@@ -13,6 +13,7 @@ proto.add = add;
 proto.getValue = getValue;
 proto.getUnit = getUnit;
 proto.getString = getString;
+proto.toString = getString;
 proto.toPrecision = toPrecision;
 
 // Expose Length prototype if user wants to add new functions.

--- a/tests/toString.test.js
+++ b/tests/toString.test.js
@@ -1,0 +1,15 @@
+const length = require('../length');
+
+describe('getString()', () => {
+  it('Should correctly return string when using toString directly', () => {
+    expect(length(1, 'cm').toString()).toEqual('1cm');
+    expect(length(0.092, 'dm').toString()).toEqual('0.092dm');
+    expect(length(30, 'mi').toString()).toEqual('30mi');
+  })
+
+  it('Should correctly return string when using toString indirectly', () => {
+    expect('' + length(1, 'cm')).toEqual('1cm');
+    expect('' + length(0.092, 'dm')).toEqual('0.092dm');
+    expect('' + length(30, 'mi')).toEqual('30mi');
+  })
+})


### PR DESCRIPTION
This adds the `toString` method for the `Length` prototype, hence using `toString` both directly and indirectly use the `getString` method instead of the default `Object` prototype implementation returning `"[object Object]"`.

Previously:
```
const l = length(12, 'cm');

console.log(l); => Length({ value: 12, unit: 'cm' })
console.log(l.toString()); => [object Object]
console.log('' + l); => [object Object]
console.log(l.getString()); => 12cm
```

With these changes:

```
const l = length(12, 'cm');

console.log(l); => Length({ value: 12, unit: 'cm' })
console.log(l.toString()); => 12cm
console.log('' + l); => 12cm
console.log(l.getString()); => 12cm
```